### PR TITLE
Set payment result callback

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,3 +1,5 @@
+import 'dart:developer';
+
 import 'package:flutter/material.dart';
 import 'package:omise_flutter/omise_flutter.dart';
 
@@ -32,9 +34,10 @@ class MyHomePage extends StatefulWidget {
 }
 
 class _MyHomePageState extends State<MyHomePage> {
-  final omisePayment = OmisePayment(publicKey: "pkey");
-  void _openPaymentMethodsPage() {
-    Navigator.push(
+  final omisePayment = OmisePayment(publicKey: "pkey_test_5tnt1gxjf6ecypmkfi8");
+  Future<void> _openPaymentMethodsPage() async {
+    final OmisePaymentResult? omisePaymentResult =
+        await Navigator.push<OmisePaymentResult>(
       context,
       MaterialPageRoute(
           builder: (context) =>
@@ -42,6 +45,14 @@ class _MyHomePageState extends State<MyHomePage> {
                 PaymentMethodName.card,
               ])),
     );
+    if (omisePaymentResult == null) {
+      log('No payment');
+    } else {
+      if (omisePaymentResult.token != null) {
+        log(omisePaymentResult.token!.id);
+      }
+      // Handle other payment results like source creation
+    }
   }
 
   @override

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -34,7 +34,7 @@ class MyHomePage extends StatefulWidget {
 }
 
 class _MyHomePageState extends State<MyHomePage> {
-  final omisePayment = OmisePayment(publicKey: "pkey_test_5tnt1gxjf6ecypmkfi8");
+  final omisePayment = OmisePayment(publicKey: "pkey");
   Future<void> _openPaymentMethodsPage() async {
     final OmisePaymentResult? omisePaymentResult =
         await Navigator.push<OmisePaymentResult>(

--- a/lib/omise_flutter.dart
+++ b/lib/omise_flutter.dart
@@ -1,4 +1,5 @@
 library omise_flutter;
 
 export 'src/services/omise_payment_service.dart';
+export 'src/models/omise_payment_result.dart';
 export 'package:omise_dart/omise_dart.dart' show PaymentMethodName;

--- a/lib/src/models/omise_payment_result.dart
+++ b/lib/src/models/omise_payment_result.dart
@@ -1,0 +1,7 @@
+import 'package:omise_dart/omise_dart.dart';
+
+class OmisePaymentResult {
+  final Token? token;
+
+  OmisePaymentResult({this.token});
+}

--- a/lib/src/pages/paymentMethods/credit_card_payment_method_page.dart
+++ b/lib/src/pages/paymentMethods/credit_card_payment_method_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:omise_dart/omise_dart.dart';
 import 'package:omise_flutter/src/controllers/credit_card_payment_method_controller.dart';
 import 'package:omise_flutter/src/enums/enums.dart';
+import 'package:omise_flutter/src/models/omise_payment_result.dart';
 import 'package:omise_flutter/src/services/omise_api_service.dart';
 import 'package:omise_flutter/src/utils/expiry_date_formatter.dart';
 import 'package:omise_flutter/src/utils/messgae_display_utils.dart';
@@ -66,7 +67,10 @@ class _CreditCardPaymentMethodPageState
             creditCardPaymentMethodController.value.tokenErrorMessage!);
       } else if (creditCardPaymentMethodController.value.tokenLoadingStatus ==
           Status.success) {
-        Navigator.of(context).popUntil((route) => route.isFirst);
+        while (Navigator.of(context).canPop()) {
+          Navigator.of(context).pop(OmisePaymentResult(
+              token: creditCardPaymentMethodController.value.token));
+        }
       }
     });
   }

--- a/test/mocks.dart
+++ b/test/mocks.dart
@@ -25,7 +25,7 @@ class MockPaymentMethodSelectorController extends Mock
 class MockCreditCardPaymentMethodController extends Mock
     implements CreditCardPaymentMethodController {}
 
-class MockCreateTokenRequest extends Fake implements CreateTokenRequest {}
+class MockCreateTokenRequest extends Mock implements CreateTokenRequest {}
 
 // Mock class for callback
 class MockCallback extends Mock {


### PR DESCRIPTION
## Description

Set the callback after the SDK is closed to allow the merchant to receive the created entity using the omise api.