### PR TITLE
Fix UserAgent web

### DIFF
--- a/lib/src/pages/paymentMethods/mobile_banking_page.dart
+++ b/lib/src/pages/paymentMethods/mobile_banking_page.dart
@@ -92,26 +92,29 @@ class _MobileBankingPageState extends State<MobileBankingPage> {
                     itemBuilder: (context, index) {
                       final paymentMethod =
                           widget.mobileBankingPaymentMethods[index];
-                      return paymentMethodTile(
-                        context: context,
-                        paymentMethod: PaymentMethodTileData(
-                          name:
-                              paymentMethod.name, // Name of the payment method
-                          leadingIcon:
-                              // condition for testing as the image will not load in test mode
-                              widget.mobileBankingPaymentMethodSelectorController !=
-                                      null
-                                  ? const SizedBox()
-                                  : Image.asset(
-                                      'assets/${paymentMethod.name.value}.png', // Icon for payment method
-                                      package: PackageInfo.packageName,
-                                      alignment: Alignment.center,
-                                    ),
-                          trailingIcon: Icons.arrow_forward_ios,
-                          onTap: () {
-                            mobileBankingPaymentMethodSelectorController
-                                .createSource(paymentMethod.name);
-                          },
+                      return Padding(
+                        padding: const EdgeInsets.only(bottom: 10),
+                        child: paymentMethodTile(
+                          context: context,
+                          paymentMethod: PaymentMethodTileData(
+                            name: paymentMethod
+                                .name, // Name of the payment method
+                            leadingIcon:
+                                // condition for testing as the image will not load in test mode
+                                widget.mobileBankingPaymentMethodSelectorController !=
+                                        null
+                                    ? const SizedBox()
+                                    : Image.asset(
+                                        'assets/${paymentMethod.name.value}.png', // Icon for payment method
+                                        package: PackageInfo.packageName,
+                                        alignment: Alignment.center,
+                                      ),
+                            trailingIcon: Icons.arrow_forward_ios,
+                            onTap: () {
+                              mobileBankingPaymentMethodSelectorController
+                                  .createSource(paymentMethod.name);
+                            },
+                          ),
                         ),
                       );
                     },

--- a/lib/src/services/omise_api_service.dart
+++ b/lib/src/services/omise_api_service.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:flutter/foundation.dart';
 import 'package:omise_dart/omise_dart.dart';
 import 'package:omise_flutter/src/utils/package_info.dart';
 
@@ -47,6 +48,11 @@ class OmiseApiService {
   String getUserAgent() {
     const sdkVersion = PackageInfo.packageVersion;
     const userAgentIdentifier = PackageInfo.userAgentIdentifier;
+    if (kIsWeb) {
+      // Browsers ignore attempts to override the user agent, and `Platform.version` causes errors on web.
+      // Return an empty string to prevent errors on web platforms.
+      return "";
+    }
     return 'dart/${Platform.version} $userAgentIdentifier/$sdkVersion (${Platform.operatingSystem} ${Platform.operatingSystemVersion})';
   }
 


### PR DESCRIPTION
## Description

The browser overrides any user agent that flutter tries to add due to security measures implemented from the browser side, and using `dart.io` in web leads to errors so the the user agent in web platforms was removed and the default was kept since it can't be changed.