### PR TITLE
Bump breaking change version 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,75 @@
-## 0.1.0
+# Changelog
 
-- Initial version
+## [0.2.0] - Major Update
+
+### Breaking Changes
+
+- **Complete Rewrite**: The library has been completely rewritten to enhance functionality, usability, and maintainability.
+- **Deprecated Legacy APIs**: All APIs and patterns from `0.1.x` series have been removed. Users of previous versions will need to migrate to the new API.
+
+### Added
+
+- **Built-in UI Components**: Introduced customizable UI components for payment processing, simplifying integration for Flutter developers.
+- **New Payment Flows**: Added support for tokenization and authorization flows.
+- **Source Creation**: Seamless support for creating sources such as:
+  - `promptpay`
+  - `mobile_banking`
+- **Internationalization (i18n)**: Added built-in support for multiple languages:
+  - English (`en`)
+  - Thai (`th`)
+  - Japanese (`ja`)
+- **Improved Debugging**: Added detailed debugging support with `enableDebug` option.
+- **Error Handling**: Built-in mechanisms to manage common payment-related errors.
+
+### Removed
+
+- Legacy code and attributes from `0.1.x` versions.
+- Examples and code patterns from the old architecture.
+
+---
+
+### Historical Archive (Pre-Rewrite)
+
+## [0.1.6] - Bug fixes
+
+- Bug fixes
+
+## [0.1.5] - Minor update
+
+- Null safety support; Thanks PR from @pitsanujiw
+
+## [0.1.4] - Minor update
+
+- Update an exmaple
+- Update packages
+- Deprecated a `security_code_check` attribute of Card API
+- Added a new attribute named `charge_status` of Token API
+
+## [0.1.3] - Update an example
+
+- Add timeout error
+
+## [0.1.2] - Update an example
+
+- Bug fixes
+
+## [0.1.1] - Update an example
+
+- Bug fixes
+
+## [0.1.0] - Update an example
+
+- Update an example
+- Update package
+- Format code
+
+## [0.0.1] - Initial release
+
+- Initial release
+
+---
+
+### Notes:
+
+- The historical changelog has been preserved for reference but is no longer actively maintained.
+- For users on `0.1.x`, upgrading to `0.2.0` is a breaking change and requires revising your integration to align with the new architecture.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 ## Features
 
+- Built in UI components.
 - Direct integration with Omise's payment gateway in Flutter apps.
 - Easy-to-use tokenization and authorization flows.
 - Easy-to-use source creation flows.
@@ -13,13 +14,29 @@
 - Built-in support for common error handling in payment processing.
 - Internationalization support for : en, th and ja.
 
+## Breaking Change - Library Rewrite
+
+The `omise_flutter` library has undergone a complete rewrite in version `0.2.0`. This major update introduces significant changes to the API and architecture, which are **not backwards compatible** with previous versions (`0.1.x` and earlier).
+
+### Key Changes:
+
+- **API Overhaul**: All existing APIs from the `0.1.x` series have been removed. The API is now more streamlined and easier to use.
+- **New UI Components**: The new version comes with built-in UI components for payment processing, providing a more user-friendly experience.
+- **Source Creation**: Added seamless support for source creation like `promptpay` and `mobile_banking`.
+- **Internationalization**: The library now supports English, Thai, and Japanese out of the box.
+- **Debugging & Error Handling**: Added enhanced debugging options and better error handling for payment flows.
+
+### Migration Notes:
+
+If you were using version `0.1.x` or earlier, you will need to update your code to align with the new API. Please refer to the [Migration Guide](link-to-migration-guide) for detailed steps on how to migrate to the new version.
+
 ## Getting Started
 
 To use the package, add it to your project by including the following in your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  omise_flutter: ^0.1.0
+  omise_flutter: ^0.2.0
 ```
 
 Run:

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The `omise_flutter` library has undergone a complete rewrite in version `0.2.0`.
 
 ### Migration Notes:
 
-If you were using version `0.1.x` or earlier, you will need to update your code to align with the new API. Please refer to the [Migration Guide](link-to-migration-guide) for detailed steps on how to migrate to the new version.
+If you were using version `0.1.x` or earlier, you will need to update your code to align with the new API as it has been completely rewritten.
 
 ## Getting Started
 

--- a/lib/src/utils/package_info.dart
+++ b/lib/src/utils/package_info.dart
@@ -11,7 +11,7 @@ class PackageInfo {
   /// The version of the package.
   ///
   /// This constant holds the package's version as defined in `pubspec.yaml`.
-  static const String packageVersion = '0.1.0';
+  static const String packageVersion = '0.2.0';
 
   static const userAgentIdentifier = 'OmiseFlutter';
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: omise_flutter
-description: "A new Flutter package project."
-version: 0.1.0
-homepage:
+description: "A Flutter SDK that serves as an API wrapper with UI components for the Omise API"
+version: 0.2.0
+repository: https://github.com/omise/omise_flutter
 
 environment:
   sdk: ^3.5.0


### PR DESCRIPTION
## Description
Versions earlier than `0.2.0` were not officially maintained and did not include the typical frontend implementations that OMISE provides. The ownership has been transferred to OMISE officially as of version `0.2.0` and this included breaking changes. In order to allow the integrators to still refer to older changelogs a history section has been added to the changelog file. 

All references to deprecated architecture has been removed and replaced with new code examples.