### PR TITLE
Fix amount tokenization methods

### DIFF
--- a/lib/src/controllers/apple_pay_controller.dart
+++ b/lib/src/controllers/apple_pay_controller.dart
@@ -6,6 +6,7 @@ import 'package:omise_dart/omise_dart.dart';
 import 'package:omise_flutter/src/enums/enums.dart';
 import 'package:omise_flutter/src/models/apple_pay_request.dart';
 import 'package:omise_flutter/src/services/omise_api_service.dart';
+import 'package:omise_flutter/src/utils/payment_utils.dart';
 
 /// The [ApplePayController] manages the state and logic for
 /// creating a mobile banking source from Omise API.
@@ -35,7 +36,7 @@ class ApplePayController extends ValueNotifier<ApplePayPageState> {
       requiredBillingContactFields:
           requiredBillingContactFields ?? ["name", "phone", "postalAddress"],
       requiredShippingContactFields: requiredShippingContactFields ?? [],
-      amount: amount,
+      amount: PaymentUtils.parseAmount(amount, currency),
       currency: currency,
       country: country,
       itemDescription: itemDescription ?? '',
@@ -94,7 +95,8 @@ class ApplePayController extends ValueNotifier<ApplePayPageState> {
         tokenRequest.billingStreet1 = postalAddress['street'];
 
         tokenRequest.billingPhoneNumber = appleBillingInfo['phoneNumber'];
-        tokenRequest.brand = value.applePaymentResult!['paymentMethod']['network'];
+        tokenRequest.brand =
+            value.applePaymentResult!['paymentMethod']['network'];
       }
       // Create the token using Omise API
       final token = await omiseApiService.createToken(tokenRequest,
@@ -146,7 +148,7 @@ class ApplePayPageState {
   final Map<String, dynamic>? applePaymentResult;
 
   /// The amount used in source creation.
-  final int? amount;
+  final num? amount;
 
   /// The currency used in source creation.
   final Currency? currency;
@@ -185,7 +187,7 @@ class ApplePayPageState {
     final List<String>? requiredShippingContactFields,
     final List<String>? requiredBillingContactFields,
     Map<String, dynamic>? applePaymentResult,
-    int? amount,
+    num? amount,
     Currency? currency,
     String? country,
     String? applePayRequest,

--- a/lib/src/controllers/google_pay_controller.dart
+++ b/lib/src/controllers/google_pay_controller.dart
@@ -6,6 +6,7 @@ import 'package:omise_dart/omise_dart.dart';
 import 'package:omise_flutter/src/enums/enums.dart';
 import 'package:omise_flutter/src/models/google_pay_request.dart';
 import 'package:omise_flutter/src/services/omise_api_service.dart';
+import 'package:omise_flutter/src/utils/payment_utils.dart';
 
 /// The [GooglePayController] manages the state and logic for
 /// creating a mobile banking source from Omise API.
@@ -33,7 +34,7 @@ class GooglePayController extends ValueNotifier<GooglePayPageState> {
       googlePayMerchantId: googlePayMerchantId,
       requestBillingAddress: requestBillingAddress,
       requestPhoneNumber: requestPhoneNumber,
-      amount: amount,
+      amount: PaymentUtils.parseAmount(amount, currency),
       currency: currency,
       itemDescription: itemDescription ?? '',
     ));
@@ -161,7 +162,7 @@ class GooglePayPageState {
   final Map<String, dynamic>? googlePaymentResult;
 
   /// The amount used in source creation.
-  final int? amount;
+  final num? amount;
 
   /// The currency used in source creation.
   final Currency? currency;
@@ -196,7 +197,7 @@ class GooglePayPageState {
     bool? requestBillingAddress,
     bool? requestPhoneNumber,
     Map<String, dynamic>? googlePaymentResult,
-    int? amount,
+    num? amount,
     Currency? currency,
     String? googlePayRequest,
     String? itemDescription,

--- a/lib/src/services/omise_payment_service.dart
+++ b/lib/src/services/omise_payment_service.dart
@@ -74,6 +74,16 @@ class OmisePayment {
   ///
   /// [googlePayItemDescription] - The description of the item being purchased for Google Pay.
   ///
+  /// [applePayRequiredShippingContactFields] - The list of required shipping contact fields for Apple Pay.
+  ///
+  /// [applePayRequiredBillingContactFields] - The list of required billing contact fields for Apple Pay.
+  ///
+  /// [appleMerchantId] - The Apple Merchant ID.
+  ///
+  /// [applePayCardBrands] - Allowed card brands for Apple Pay (e.g., ['visa', 'mastercard']).
+  ///
+  /// [applePayItemDescription] - The description of the item being purchased for Apple Pay.
+  ///
   /// [atomeItems] - The list of items being purchased when using the atome payment method.
   ///
   /// Returns a [Widget] that represents the payment method selection page.

--- a/lib/src/utils/payment_utils.dart
+++ b/lib/src/utils/payment_utils.dart
@@ -85,4 +85,18 @@ class PaymentUtils {
     }
     return 'assets/fpxBanks/${bankName.value}.png';
   }
+
+  /// Parses the amount based on the currency.
+  ///
+  /// For currencies other than JPY, the amount is divided by 100.
+  ///
+  /// Args:
+  ///   amount: The amount to parse.
+  ///   currency: The currency of the amount.
+  ///
+  /// Returns:
+  ///   The parsed amount as a number.
+  static num parseAmount(num amount, Currency currency) {
+    return currency != Currency.jpy ? amount / 100 : amount;
+  }
 }

--- a/test/controllers/apple_pay_controller_test.dart
+++ b/test/controllers/apple_pay_controller_test.dart
@@ -60,7 +60,7 @@ void main() {
 
       expect(applePayController.value.applePayMerchantId, 'merchant_123');
       expect(applePayController.value.country, 'TH');
-      expect(applePayController.value.amount, 1000);
+      expect(applePayController.value.amount, 10);
       expect(applePayController.value.currency, Currency.thb);
       expect(applePayController.value.itemDescription, 'Test Item');
     });

--- a/test/controllers/google_pay_controller_test.dart
+++ b/test/controllers/google_pay_controller_test.dart
@@ -62,7 +62,7 @@ void main() {
       expect(googlePayController.value.googlePayMerchantId, 'merchant_123');
       expect(googlePayController.value.requestBillingAddress, true);
       expect(googlePayController.value.requestPhoneNumber, true);
-      expect(googlePayController.value.amount, 1000);
+      expect(googlePayController.value.amount, 10);
       expect(googlePayController.value.currency, Currency.thb);
       expect(googlePayController.value.itemDescription, 'Test Item');
     });


### PR DESCRIPTION
## Description
The amount being passed from the user to the omise integration follows the omise api precision but in google and apple pay the amount is following a different format. 
To fix this, the amount is divided by 100 when the currency is not JPY.
## Rollback procedure
default rollback procedure