### PR TITLE
Add id-token permissions to enable automatic deployment

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,6 +37,8 @@ jobs:
 
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write # Required for authentication using OIDC
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## Description

Fix automatic deployment with no user interaction, reference error:
```
Total compressed archive size: 671 KB.
Validating package...
Pub needs your authorization to upload packages on your behalf.
In a web browser, go to ...
``` 